### PR TITLE
Note that Wiley eText has been removed from the US app store.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The applications listed below have been developed out of Thorium Reader, which i
 ## Other Desktop Apps
 
 Using Readium JS:
-* [Wiley eText (MacOS)](https://apps.apple.com/fr/app/wiley-etext/id1523684519) - an education reader developed by Wiley Publishing.
+* [Wiley eText (MacOS)](https://apps.apple.com/fr/app/wiley-etext/id1523684519) - an education reader developed by Wiley Publishing. (Has been [removed](https://web.archive.org/web/20220320041556/https://apps.apple.com/us/app/id1523684519) from the US app store.) 
 
 ## Apps based on Readium Web
 


### PR DESCRIPTION
Wiley eText has been [removed](https://web.archive.org/web/20220320041556/https://apps.apple.com/us/app/id1523684519) from the US app store but seems to be widely available https://www.google.com/search?q=apple.com+app+%22id1523684519%22.  Help confused users with a message - e.g. this one? 